### PR TITLE
[Insight] Symfony secret should be changed

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -16,4 +16,4 @@ parameters:
     mailer_password:   ~
 
     # A secret key that's used to generate certain security-related tokens
-    secret:            ThisTokenIsNotSoSecretChangeIt
+    secret:            729ac5a6045e8c851b5424a05c8d0b888a63e77f


### PR DESCRIPTION
Fix for issue #1.

> In this project I'm using a basic hash genereated on http://nux.net/secret, but in a real production environment, the best approach would be to provide such value through a build/deployment process, using Puppet or any other provisioning tool.
